### PR TITLE
Change IFS to ":" to enable php options for atoum.

### DIFF
--- a/autotoum
+++ b/autotoum
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+IFS=":"
 PIPE=/tmp/autotoum_$$
 ATOUM=bin/atoum
 SOURCES="$(pwd)/src $(pwd)/tests/units"
@@ -107,6 +108,7 @@ do
             ATOUM=$OPTARG
             ;;
         w)
+            IFS=' ';
             SOURCES=$(echo $OPTARG | sed "s/,/ /g")
             for entry in $SOURCES
             do
@@ -116,6 +118,7 @@ do
                     exit 1
                 fi
             done
+            IFS=':';
             ;;
         ?)
             usage


### PR DESCRIPTION
Autotoum allow to use all options from atoum but some of them should be
include in single quotes or double quotes. The problem is shell parse
all data and remove quotes so after we have a string which include wrong
options to atoum to avoid this we need to change the IFS char to allow
space into atoum's argument "-p".

Now you can specify php module used in atoum with autotoum. But you need
to separate all options with ":"

Exemple:

autotoum -- -ncc:-p 'php -n -ddate.timezone=Eurore/Paris':-mcn 3
